### PR TITLE
Fix registered campaigns check

### DIFF
--- a/Model/Config/Source/Carts/Campaigns.php
+++ b/Model/Config/Source/Carts/Campaigns.php
@@ -27,7 +27,7 @@ class Campaigns implements \Magento\Framework\Option\ArrayInterface
         if ($apiEnabled) {
             $savedCampaigns = $this->_registry->registry('campaigns');
 
-            if ($savedCampaigns) {
+            if (isset($savedCampaigns)) {
                 $campaigns = $savedCampaigns;
             } else {
                 //grab the datafields request and save to register


### PR DESCRIPTION
Without isset the expression evaluates to false if $savedCampaigns is an empty array. In this case register throws an exception.