### PR TITLE
Check campaigns are not empty before iterating.

### DIFF
--- a/Model/Config/Source/Carts/Campaigns.php
+++ b/Model/Config/Source/Carts/Campaigns.php
@@ -40,7 +40,7 @@ class Campaigns implements \Magento\Framework\Option\ArrayInterface
             if (isset($campaigns->message)) {
                 //message
                 $fields[] = array('value' => 0, 'label' => $campaigns->message);
-            } else {
+            } elseif (!empty($campaigns)) {
                 //loop for all campaing option
                 foreach ($campaigns as $campaign) {
                     if (isset($campaign->name)) {


### PR DESCRIPTION
Current implementation allows $campaings to be NULL hence one could get the following error:
Warning: Invalid argument supplied for foreach() in /vendor/dotmailer/dotmailer-magento2-extension/Model/Config/Source/Carts/Campaigns.php on line 45
This quick fix is to check the variable before iterating.