### PR TITLE
Fix module.xml. Use Csv proxy for Model\Cron class.

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,4 +26,9 @@
             <argument name="target" xsi:type="object">Magento\Catalog\Pricing\Price\Pool</argument>
         </arguments>
     </virtualType>
+    <type name="Dotdigitalgroup\Email\Model\Cron">
+        <arguments>
+            <argument name="csv" xsi:type="object">Magento\ImportExport\Model\Export\Adapter\Csv\Proxy</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Dotdigitalgroup_Email" setup_version="1.1.8">
-     <sequence>
- +            <module name="Magento_Customer"/>
- +            <module name="Magento_Newsletter"/>
- +            <module name="Magento_Review"/>
- +        </sequence>
+        <sequence>
+            <module name="Magento_Wishlist"/>
+            <module name="Magento_Newsletter"/>
+            <module name="Magento_Review"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
This is clearly a mistake in module.xml which makes it invalid with extra "+" characters.
The Proxy is to fix var directory spamming with importexport files.