### PR TITLE
Data presence check improved in wishlist_remove_after observer

### DIFF
--- a/Observer/Customer/RemoveWishlist.php
+++ b/Observer/Customer/RemoveWishlist.php
@@ -73,7 +73,7 @@ class RemoveWishlist implements \Magento\Framework\Event\ObserverInterface
             try {
                 $item = $this->_wishlistFactory->create()
                     ->getWishlist($object->getWishlistId());
-                if ($item->getId()) {
+                if (($item instanceof \Magento\Framework\DataObject) && $item->getId()) {
                     //register in queue with importer
                     $this->_importerFactory->create()->registerQueue(
                         \Dotdigitalgroup\Email\Model\Importer::IMPORT_TYPE_WISHLIST,


### PR DESCRIPTION
When syncing enabled email_wishlist item is created only after addition of first product to wishlist and because of that fact during an attempt of deletion of empty wishlist error is occured:

2016/09/02 12:13:42 [error] 9857#0: *41637 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Call to a member function getId() on boolean in /var/www/xxxxxxxx.xxxxxxxx.com.au/html/ffs/vendor/dotmailer/dotmailer-magento2-extension/Observer/Customer/RemoveWishlist.php on line 76" while reading response header from upstream, client: XXX.XXX.XXX.XXX, server: xxxxxxxx.xxxxxxxx.com.au, request: "POST /wishlist/index/deletewishlist/wishlist_id/36/ HTTP/1.1", upstream: "fastcgi://unix:/run/php/php5.6-fpm.sock:", host: "xxxxxxxx.xxxxxxxx.com.au", referrer: "http://xxxxxxxx.xxxxxxxx.com.au/wishlist/index/index/wishlist_id/36/"