### PR TITLE
Coupon application problem

### DIFF
--- a/Controller/Adminhtml/Dashboard/Grid.php
+++ b/Controller/Adminhtml/Dashboard/Grid.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dotdigitalgroup\Email\Controller\Adminhtml\Cron;
+namespace Dotdigitalgroup\Email\Controller\Adminhtml\Dashboard;
 
 class Grid extends Index
 {

--- a/Model/SalesRule/Collection.php
+++ b/Model/SalesRule/Collection.php
@@ -32,7 +32,7 @@ class Collection extends \Magento\SalesRule\Model\ResourceModel\Rule\Collection
 
             /* We need to overwrite joinLeft if coupon is applied */
             $this->getSelect()->reset();
-            parent::_initSelect();
+            $this->getSelect()->from(['main_table' => $this->getMainTable()]);
 
             $this->addWebsiteGroupDateFilter($websiteId, $customerGroupId, $now);
             $select = $this->getSelect();


### PR DESCRIPTION
My current setup is based on:
- Magento 2.1.2 EE
- Dotmailer 2.1.1

THe problem appears when coupon code applied on checkout via discount code application form. The exception is next:
`[2016-10-19 00:36:20] report.CRITICAL: exception 'Zend_Db_Select_Exception' with message 'You cannot define a correlation name 'rule_coupons' more than once' in /var/www/src/vendor/magento/zendframework1/library/Zend/Db/Select.php:810
Stack trace:
# 0 /var/www/src/vendor/magento/framework/DB/Select.php(298): Zend_Db_Select->_join('left join', Array, 'main_table.rule...', Array, NULL)
# 1 /var/www/src/vendor/magento/zendframework1/library/Zend/Db/Select.php(359): Magento\Framework\DB\Select->_join('left join', Array, 'main_table.rule...', Array, NULL)
# 2 /var/www/src/vendor/dotmailer/dotmailer-magento2-extension/Model/SalesRule/Collection.php(49): Zend_Db_Select->joinLeft(Array, 'main_table.rule...', Array)
# 3 /var/www/src/vendor/magento/framework/Interception/Interceptor.php(74): Dotdigitalgroup\Email\Model\SalesRule\Collection->setValidationFilter('1', '0', 'HELLO20', NULL)
# 4 /var/www/src/vendor/magento/framework/Interception/Chain/Chain.php(70): Dotdigitalgroup\Email\Model\SalesRule\Collection\Interceptor->___callParent('setValidationFi...', Array)
# 5 /var/www/src/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\Interception\Chain\Chain->invokeNext('Dotdigitalgroup...', 'setValidationFi...', Object(Dotdigitalgroup\Email\Model\SalesRule\Collection\Interceptor), Array, 'aroundSetValida...')

`

Problem is caused by inheritance. Parent class method setValidationFilter (which was used as source for dotamailer solution) uses parent class _initSelect method **_initSelect**:

``` php
parent::_initSelect();
```

In case of parent class - parent::_initSelect method just defines main table:

``` php
$this->getSelect()->from(['main_table' => $this->getMainTable()]);
```

but when calling parent::_initSelect in dotmailer class we're defining also **rule_coupons** table:

``` php
parent::_initSelect();
$this->getSelect()->joinLeft(
    ['rule_coupons' => $this->getTable('salesrule_coupon')],
    'main_table.rule_id = rule_coupons.rule_id AND rule_coupons.is_primary = 1',
    ['code']
);
```

 which also defined in setValidationFilter method almost immediately after calling parent method:

``` php
$select->joinLeft(
    ['rule_coupons' => $this->getTable('salesrule_coupon')],
    $connection->quoteInto(
        'main_table.rule_id = rule_coupons.rule_id AND main_table.coupon_type != ?',
        \Magento\SalesRule\Model\Rule::COUPON_TYPE_NO_COUPON
    ),
    ['code']
);
```

Assumption: get rid of usage of parent  method call and just use grandparent method code.
