### PR TITLE
Master wrong namespace

### DIFF
--- a/Controller/Adminhtml/Dashboard/Grid.php
+++ b/Controller/Adminhtml/Dashboard/Grid.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dotdigitalgroup\Email\Controller\Adminhtml\Cron;
+namespace Dotdigitalgroup\Email\Controller\Adminhtml\Dashboard;
 
 class Grid extends Index
 {

--- a/Controller/Adminhtml/Dashboard/MassDelete.php
+++ b/Controller/Adminhtml/Dashboard/MassDelete.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dotdigitalgroup\Email\Controller\Adminhtml\Cron;
+namespace Dotdigitalgroup\Email\Controller\Adminhtml\Dashboard;
 
 use Magento\Framework\Controller\ResultFactory;
 


### PR DESCRIPTION
During composer update with updating loader such error message is generated:

`Warning: Ambiguous class resolution, "Dotdigitalgroup\Email\Controller\Adminhtml\Cron\Grid" was found in both "<LOCAL_PATH>/src/vendor/dotmailer/dotmailer-magento2-extension/Controller/Adminhtml/Cron/Grid.php" and "<LOCAL_PATH>/src/vendor/dotmailer/dotmailer-magento2-extension/Controller/Adminhtml/Dashboard/Grid.php", the first will be used.
Warning: Ambiguous class resolution, "Dotdigitalgroup\Email\Controller\Adminhtml\Cron\MassDelete" was found in both "<LOCAL_PATH>/src/vendor/dotmailer/dotmailer-magento2-extension/Controller/Adminhtml/Cron/MassDelete.php" and "<LOCAL_PATH>/src/vendor/dotmailer/dotmailer-magento2-extension/Controller/Adminhtml/Dashboard/MassDelete.php", the first will be used.`

Setup:
- M2 EE 2.1.2
- Dotmailer 2.1.1
