### PR TITLE
Added virtual type for Zend_Date

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -25,4 +25,16 @@
             <argument name="target" xsi:type="object">Magento\Catalog\Pricing\Price\Pool</argument>
         </arguments>
     </virtualType>
+    <virtualType name="dotdigitalgroupZendDate" type="Zend_Date">
+        <arguments>
+            <argument name="date" xsi:type="null"/>
+            <argument name="part" xsi:type="null"/>
+            <argument name="locale" xsi:type="null"/>
+        </arguments>
+    </virtualType>
+    <type name="Dotdigitalgroup\Email\Model\Sales\Order">
+        <arguments>
+            <argument name="date" xsi:type="object">dotdigitalgroupZendDate</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Hi,

I'm observing an issue with "ddg_automation_reviews_and_wishlist" cron job. It fails with an error 
Recoverable Error: Object of class Magento\Framework\ObjectManager\ObjectManager could not be converted to string in /data/www/html/www.familyvideo.com/htdocs/vendor/magento/zendframework1/library/Zend/Date.php on line 156

I have some insight on this issue. Our server is running in production mode, and in this mode, after compiling DI configuration, Magento 2 passes ObjectManager to constructor as last parameter. If no other parameters specified it will become the one  parameter. As a result, in some ZF classes, it will resulting an error, because they expect either string or some specific object, or null. 

So, my suggestion here is not use Zend_Date and use some Magento 2 class. Or, this behawior can be changed by creating virtual type in di.xml. I already did this for Zend_Http_Client parameters. So, in your case, it will look like below.

Please let me know if you have any questions.
