### PR TITLE
Production mode compatibility for Zend_ classes

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -28,4 +28,36 @@
             </argument>
         </arguments>
     </type>
+
+    <!-- Production mode compatibility for Zend_Date -->
+    <virtualType name="dotdigitalgroupZendDate" type="Zend_Date">
+        <arguments>
+            <argument name="date" xsi:type="null"/>
+            <argument name="part" xsi:type="null"/>
+            <argument name="locale" xsi:type="null"/>
+        </arguments>
+    </virtualType>
+    <type name="Dotdigitalgroup\Email\Model\Sales\Order">
+        <arguments>
+            <argument name="date" xsi:type="object">dotdigitalgroupZendDate</argument>
+        </arguments>
+    </type>
+    <type name="Dotdigitalgroup\Email\Helper\Recommended">
+        <arguments>
+            <argument name="date" xsi:type="object">dotdigitalgroupZendDate</argument>
+        </arguments>
+    </type>
+
+    <!-- Production mode compatibility for Zend_Mail_Transport_Sendmail -->
+    <virtualType name="dotdigitalgroupZendMailTransportSendmail" type="Zend_Mail_Transport_Sendmail">
+        <arguments>
+            <argument name="parameters" xsi:type="null"/>
+        </arguments>
+    </virtualType>
+    <type name="Dotdigitalgroup\Email\Model\Mail\Transport">
+        <arguments>
+            <argument name="sendmail" xsi:type="object">dotdigitalgroupZendMailTransportSendmail</argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Please review a compatibility fix. 

It solves an issue with Magento 2, running in "production" mode. In this mode Object Manager passes itself as a parameter to constructor for parameters with default value null