### PR TITLE
Add name key to helper's Transport Configuration

### DIFF
--- a/Helper/Transactional.php
+++ b/Helper/Transactional.php
@@ -111,6 +111,7 @@ class Transactional extends \Magento\Framework\App\Helper\AbstractHelper
     public function getTransportConfig()
     {
         $config = [
+            'name' => $this->getSmtpHost(),
             'port' => $this->getSmtpPort(),
             'auth' => 'login',
             'username' => $this->getSmtpUsername(),


### PR DESCRIPTION
When we eventually get down to [Magento's \Zend_Mail_Transport_Smtp::_sendMail](https://github.com/magento/zf1/blob/master/library/Zend/Mail/Transport/Smtp.php#L200), you'll see it calls `$this->_connection->helo($this->_name)`.

If name is not passed in the transport config, it assumes a name of localhost, and attempts to connect to that to send the HELO.

This is occurring in Magento 2.1.4