### PR TITLE
Fix "Notice: Undefined offset: 1"

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1856,6 +1856,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         preg_match("/https:\/\/(.*)api.dotmailer.com/", $apiEndpoint, $matches);
-        return $matches[1];
+        return isset($matches[1]) ? $matches[1] : '';
     }
 }


### PR DESCRIPTION
Hi. 

On enabled strict PHP errors reporting I saw a following error on homepage:
```
Notice: Undefined offset: 1
```

Here's a fix for that. 
The reason of that was an invalid domain configuration in "API Endpoint Config".

To improve the fix I can also add a logging message like "Invalid API Endpoint Server". What do you think?