### PR TITLE
Changing mode used in pathExists method

### DIFF
--- a/Helper/File.php
+++ b/Helper/File.php
@@ -183,7 +183,7 @@ class File
     private function pathExists($path)
     {
         if (!is_dir($path)) {
-            mkdir($path, 750, true);
+            mkdir($path, 0750, true);
         }
     }
 


### PR DESCRIPTION
Current mode leaves folder unable to be deleted by normal web user.

See issue #515 