### PR TITLE
Fixed incorrect node name.

### DIFF
--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -29,7 +29,7 @@
             <config_path>connector_developer_settings/cron_schedules/catalog</config_path>
         </job>
         <job name="ddg_automation_email_templates" instance="Dotdigitalgroup\Email\Model\Cron" method="syncEmailTemplates">
-            <config_path>0 */6 * * *</config_path>
+            <schedule>0 */6 * * *</schedule>
         </job>
     </group>
 </config>


### PR DESCRIPTION
A config_path node was used for the schedule for the ddg_automation_email_templates cronjob. This should be a schedule node.