### PR TITLE
Move getConfigurableParentUrl and getSmallImageUrl block methods to b…

### DIFF
--- a/Block/Recommended.php
+++ b/Block/Recommended.php
@@ -59,4 +59,21 @@ class Recommended extends \Magento\Catalog\Block\Product\AbstractProduct
     {
         return $this->urlFinder->getProductImageUrl($product, $imageId);
     }
+
+    /**
+     * Return a product's parent URL, if it has one.
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     *
+     * @return string
+     */
+    public function getConfigurableParentUrl($product)
+    {
+        return $this->urlFinder->fetchFor($product);
+    }
+
+    public function getSmallImageUrl($product, $imageId)
+    {
+        return $this->urlFinder->getProductImageUrl($product, $imageId);
+    }
 }

--- a/Block/Recommended.php
+++ b/Block/Recommended.php
@@ -72,6 +72,14 @@ class Recommended extends \Magento\Catalog\Block\Product\AbstractProduct
         return $this->urlFinder->fetchFor($product);
     }
 
+    /**
+     * Return a product's image URL, if it has one.
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     * @param string $imageId
+     *
+     * @return string
+     */
     public function getSmallImageUrl($product, $imageId)
     {
         return $this->urlFinder->getProductImageUrl($product, $imageId);

--- a/Block/Recommended/Bestsellers.php
+++ b/Block/Recommended/Bestsellers.php
@@ -101,21 +101,4 @@ class Bestsellers extends \Dotdigitalgroup\Email\Block\Recommended
             \Dotdigitalgroup\Email\Helper\Config::XML_PATH_CONNECTOR_DYNAMIC_CONTENT_LINK_TEXT
         );
     }
-
-    /**
-     * Return a product's parent URL, if it has one.
-     *
-     * @param \Magento\Catalog\Model\Product $product
-     *
-     * @return string
-     */
-    public function getConfigurableParentUrl($product)
-    {
-        return $this->urlFinder->fetchFor($product);
-    }
-
-    public function getSmallImageUrl($product, $imageId)
-    {
-        return $this->urlFinder->getProductImageUrl($product, $imageId);
-    }
 }


### PR DESCRIPTION
…e available for all product list templates

Resolves #547 

Moves the `getConfigurableParentUrl` and `getSmallImageUrl` methods to Block/Recommended which all relevant block files will inherit these methods from.