### PR TITLE
Provide fallback store id in OrderSaveAfter observer

### DIFF
--- a/Observer/Sales/OrderSaveAfter.php
+++ b/Observer/Sales/OrderSaveAfter.php
@@ -150,6 +150,9 @@ class OrderSaveAfter implements \Magento\Framework\Event\ObserverInterface
         $store      = $this->storeManager->getStore($storeId);
         $storeName  = $store->getName();
         $websiteId  = $store->getWebsiteId();
+        if (empty($storeId)) {
+            $storeId = $store->getId();
+        }
         // start app emulation
         $appEmulation = $this->emulationFactory->create();
         $appEmulation->startEnvironmentEmulation($storeId);


### PR DESCRIPTION
Fix 502 error on POST API Call

We upgraded dotdigital email module from v4.12.0 to v.4.19.3 on our Magento 2 store (Magento version 2.4.3-p2).
 
After the dotdigital module upgrade, the order post API call is not working. It's throwing 502 error.
 
```
curl --location --request POST 'https://mydomain.test/rest/V1/orders' \
--header 'Authorization: Bearer l5xxxxublxxxxxxxxxxigozdxxxxxjw' \
--header 'Content-Type: application/json' \
--data-raw '{
    "entity" : {
        "entity_id" : 11683,
        "increment_id" : "000011554",
        "status": "picked"
    }
}'
```
 
The `$storeId` was `null` on the REST API Call.

This PR fixes the issue.