### PR TITLE
Use laminas library instead of zend

### DIFF
--- a/Model/Catalog/UrlFinder.php
+++ b/Model/Catalog/UrlFinder.php
@@ -10,7 +10,7 @@ use Magento\Catalog\Block\Product\ImageBuilder;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use \Laminas\Uri\Http;
+use Laminas\Uri\Http;
 
 class UrlFinder
 {

--- a/Model/Catalog/UrlFinder.php
+++ b/Model/Catalog/UrlFinder.php
@@ -10,7 +10,7 @@ use Magento\Catalog\Block\Product\ImageBuilder;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Zend\Uri\Http;
+use \Laminas\Uri\Http;
 
 class UrlFinder
 {

--- a/Test/Unit/Model/Catalog/UrlFinderTest.php
+++ b/Test/Unit/Model/Catalog/UrlFinderTest.php
@@ -13,7 +13,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Website;
-use Zend\Uri\Http;
+use Laminas\Uri\Http;
 use PHPUnit\Framework\TestCase;
 
 class UrlFinderTest extends TestCase


### PR DESCRIPTION
Hello,
I have noticed a problem while running cronjob: ddg_automation_subscriber_sync
Class Zend\Uri\Http doesn't exist. I think we should use Laminas\Uri\Http instead.



Magento 2.4.5
PHP8.1
![Screenshot 2022-12-20 at 14 18 35](https://user-images.githubusercontent.com/11822697/208676693-52c88451-5058-4eea-a836-f386dbc3d8ea.png)
