### PR TITLE
Fix abandon cart quote merging issue with configurable products

### DIFF
--- a/Controller/Email/Getbasket.php
+++ b/Controller/Email/Getbasket.php
@@ -199,16 +199,24 @@ class Getbasket extends \Magento\Framework\App\Action\Action
 
         if ($currentQuote->hasItems()) {
             foreach ($this->quote->getAllVisibleItems() as $item) {
+                $found = false;
+                
                 foreach ($currentQuote->getAllItems() as $quoteItem) {
-                    if (!$quoteItem->compare($item)) {
-                        $newItem = clone $item;
-                        $currentQuote->addItem($newItem);
-                        if ($item->getHasChildren()) {
-                            foreach ($item->getChildren() as $child) {
-                                $newChild = clone $child;
-                                $newChild->setParentItem($newItem);
-                                $currentQuote->addItem($newChild);
-                            }
+                    if ($quoteItem->compare($item)) {
+                        $quoteItem->setQty($quoteItem->getQty() + $item->getQty());
+                        $found = true;
+                        break;
+                    }
+                }
+
+                if (!$found) {
+                    $newItem = clone $item;
+                    $currentQuote->addItem($newItem);
+                    if ($item->getHasChildren()) {
+                        foreach ($item->getChildren() as $child) {
+                            $newChild = clone $child;
+                            $newChild->setParentItem($newItem);
+                            $currentQuote->addItem($newChild);
                         }
                     }
                 }

--- a/Controller/Email/Getbasket.php
+++ b/Controller/Email/Getbasket.php
@@ -203,7 +203,6 @@ class Getbasket extends \Magento\Framework\App\Action\Action
                 
                 foreach ($currentQuote->getAllItems() as $quoteItem) {
                     if ($quoteItem->compare($item)) {
-                        $quoteItem->setQty($quoteItem->getQty() + $item->getQty());
                         $found = true;
                         break;
                     }

--- a/Controller/Email/Getbasket.php
+++ b/Controller/Email/Getbasket.php
@@ -199,24 +199,16 @@ class Getbasket extends \Magento\Framework\App\Action\Action
 
         if ($currentQuote->hasItems()) {
             foreach ($this->quote->getAllVisibleItems() as $item) {
-                $found = false;
-                
                 foreach ($currentQuote->getAllItems() as $quoteItem) {
-                    if ($quoteItem->compare($item)) {
-                        $quoteItem->setQty($quoteItem->getQty() + $item->getQty());
-                        $found = true;
-                        break;
-                    }
-                }
-
-                if (!$found) {
-                    $newItem = clone $item;
-                    $currentQuote->addItem($newItem);
-                    if ($item->getHasChildren()) {
-                        foreach ($item->getChildren() as $child) {
-                            $newChild = clone $child;
-                            $newChild->setParentItem($newItem);
-                            $currentQuote->addItem($newChild);
+                    if (!$quoteItem->compare($item)) {
+                        $newItem = clone $item;
+                        $currentQuote->addItem($newItem);
+                        if ($item->getHasChildren()) {
+                            foreach ($item->getChildren() as $child) {
+                                $newChild = clone $child;
+                                $newChild->setParentItem($newItem);
+                                $currentQuote->addItem($newChild);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This is a clean state branch copy for https://github.com/dotmailer/dotmailer-magento2-extension/pull/601

### Original Issue:
When an abandoned cart contains configurable items, the original method won't be able to add the parent due to missing selected options on `$currentQuote->addProduct($item->getProduct());`
See screenshot as example
![Screenshot 2023-02-09 at 18 59 06](https://user-images.githubusercontent.com/49101304/218897318-c8536f70-f72f-4431-9ace-cc546e2c548a.png)

### Solution:
Using getAllVisibleItems() instead, and loop through visible items to check for simple products that are contained within a configurable product. This method is borrowed from the merge() function within Quote but slightly simplified to match the original implementation. 


### Replication steps
1. on browser A, add a configurable product to cart
2. then on browser B, add another configurable product to cart
3. on browser B, access {siteURL}/connector/email/getbasket/quote_id/{the quote created on step 1}/

The assumption
- the customer has added an item using a device e.g. phone added an item to the basket 
- the customer got an abandoned cart email and opened on another device e.g. desktop 
- the customer opened the email while they might have an item within the basket already (either from current the session or as a logged-in customer who has a cart saved)


