### PR TITLE
Add fallback selector for WBT in case #search is not present 

### DIFF
--- a/view/frontend/web/js/webBehaviorTracking.js
+++ b/view/frontend/web/js/webBehaviorTracking.js
@@ -111,7 +111,8 @@ define([
                 body = document.getElementsByTagName('body')[0];
 				
             if (body.classList.contains('catalogsearch-result-index')) {
-				var search = document.getElementsByName('q')[0];
+				var search = document.getElementById('search') ? document.getElementById('search') : document.getElementsByName('q').length ? document.getElementsByName('q')[0] : null;
+				
                 if (search && search.hasAttribute('value')) {
                     this.wbtTrack({
                         'searched_term': search.getAttribute('value')

--- a/view/frontend/web/js/webBehaviorTracking.js
+++ b/view/frontend/web/js/webBehaviorTracking.js
@@ -109,10 +109,9 @@ define([
         'Dotdigitalgroup_Email/js/webBehaviorTracking': function (settings) {
             var wbt = this.initWbt(settings.id, settings.subdomain, settings.region),
                 body = document.getElementsByTagName('body')[0];
-
+				
             if (body.classList.contains('catalogsearch-result-index')) {
-                var search = document.getElementById('search');
-
+				var search = document.getElementsByName('q')[0];
                 if (search && search.hasAttribute('value')) {
                     this.wbtTrack({
                         'searched_term': search.getAttribute('value')

--- a/view/frontend/web/js/webBehaviorTracking.js
+++ b/view/frontend/web/js/webBehaviorTracking.js
@@ -108,11 +108,12 @@ define([
          */
         'Dotdigitalgroup_Email/js/webBehaviorTracking': function (settings) {
             var wbt = this.initWbt(settings.id, settings.subdomain, settings.region),
-                body = document.getElementsByTagName('body')[0];
-				
+                body = document.getElementsByTagName('body')[0],
+                search = document.getElementById('search') ?
+                    document.getElementById('search') :
+                    document.getElementsByName('q').length ? document.getElementsByName('q')[0] : null;
+
             if (body.classList.contains('catalogsearch-result-index')) {
-				var search = document.getElementById('search') ? document.getElementById('search') : document.getElementsByName('q').length ? document.getElementsByName('q')[0] : null;
-				
                 if (search && search.hasAttribute('value')) {
                     this.wbtTrack({
                         'searched_term': search.getAttribute('value')


### PR DESCRIPTION
Additional fix on to PR 47992 - https://github.com/dotmailer/dotmailer-magento2-extension/commit/056369ac9d3971474bb7541c23ea0c77cc626d4b

## What's being changed
Original PR solves the problem of JS errors but not covering a wider net to try and locatet the search value - which can be caused by search modules.
Add Fallback to try and Get search input by name if no Id = search.

If can't find any, set var search to null, so previous added checks still work.

## Why it's being changed

It is possible that different HTML structures can mean there is no `<input id="search">` which we look for when tracking the last search term.
---
So add a fallback to try and locate the search input for `<input name="q">` 

Seen modules/themes change the ID of the input, but not seen one that changes the name attribute.

Covers a wider net to allow WBT to work with more magento modules/themes.

## How to review / test this change
- Test with core magento. - finds search.
- Test with a search module I.E. ElastiSuite. - now finds search.
- Test with any other module that replaces search input.
- You can also set `search = null` in the code in order to simulate the original reported problem

