### PR TITLE
fix: add translatable string

### DIFF
--- a/view/frontend/templates/customer/account-subscriptions.phtml
+++ b/view/frontend/templates/customer/account-subscriptions.phtml
@@ -17,7 +17,7 @@
     <div class="actions-toolbar">
         <div class="primary">
             <button type="submit" title="Save" class="action save primary">
-                <span>Save</span>
+                <span><?= $escaper->escapeHtml(__('Save')); ?></span>
             </button>
         </div>
     </div>

--- a/view/frontend/templates/customer/account-subscriptions.phtml
+++ b/view/frontend/templates/customer/account-subscriptions.phtml
@@ -17,7 +17,7 @@
     <div class="actions-toolbar">
         <div class="primary">
             <button type="submit" title="Save" class="action save primary">
-                <span><?= $escaper->escapeHtml(__('Save')); ?></span>
+                <span><?= $block->escapeHtml(__('Save')); ?></span>
             </button>
         </div>
     </div>


### PR DESCRIPTION
Small adjustment to `.phtml` template to allow string translation