### PR TITLE
EXAMPLE Add logging prior to calling array_combine

### DIFF
--- a/Model/Sync/Automation/DataField/DataFieldCollector.php
+++ b/Model/Sync/Automation/DataField/DataFieldCollector.php
@@ -151,8 +151,8 @@ class DataFieldCollector
         }
 
         return array_combine(
-            $exporter->getCsvColumns(),
-            $keyedExport[$contact->getId()]
+            $keys,
+            $values
         );
     }
 


### PR DESCRIPTION
Bear in mind if you add this, and your code does hit the error, we will sync the contact regardless without data fields. This is not optimal and may impact the behaviour of your program. So arguably we should throw an exception here, but I've put it like this for now to demonstrate, so we get past this step, and so that if there are _further_ errors in the process we may see those as well. 