### PR TITLE
refactor: DD-dashboard-reset-broken add JS to initialise reset-bnt click listeners

### DIFF
--- a/view/adminhtml/layout/dotdigitalgroup_email_dashboard_index.xml
+++ b/view/adminhtml/layout/dotdigitalgroup_email_dashboard_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
+        <script src="Dotdigitalgroup_Email::js/daterange.js"/>
         <css src="Dotdigitalgroup_Email::styles.css"/>
     </head>
     <body>


### PR DESCRIPTION
Reset buttons don't work on Reports -> Customer Engagement -> Dashboard page