### PR TITLE
Fix critical error via array typecasting

### DIFF
--- a/Model/Config/Source/Automation/Program.php
+++ b/Model/Config/Source/Automation/Program.php
@@ -63,7 +63,7 @@ class Program implements \Magento\Framework\Data\OptionSourceInterface
                     $programResponse = $client->getPrograms(count($programs));
 
                     if (is_object($programResponse)) {
-                        $programs = $programResponse;
+                        $programs = (array) $programResponse;
                         break;
                     }
 
@@ -74,9 +74,9 @@ class Program implements \Magento\Framework\Data\OptionSourceInterface
             }
 
             //set the api error message for the first option
-            if (isset($programs->message)) {
+            if (isset($programs['message'])) {
                 //message
-                $fields[] = ['value' => 0, 'label' => $programs->message];
+                $fields[] = ['value' => 0, 'label' => $programs['message']];
             } elseif (!empty($programs)) {
                 //sort programs by status
                 $statusOrder = ['Active','Draft','ReadOnly','Deactivated','NotAvailableInThisVersion'];


### PR DESCRIPTION
In the admin under **Config > DotDigital > Automation**, this PR/fix avoid the following: 

```
[2025-03-07T11:54:24.892446+00:00] main.CRITICAL: TypeError: array_map(): Argument #2 ($array) must be of type array, stdClass given in /kit-app/src/vendor/dotdigital/dotdigital-magento2-extension/Model/Config/Source/Automation/Program.php:84
Stack trace:
#0 /kit-app/src/vendor/dotdigital/dotdigital-magento2-extension/Model/Config/Source/Automation/Program.php(84): array_map(Object(Closure), Object(stdClass))
```